### PR TITLE
Reset content refresh time stamp

### DIFF
--- a/components/flushnews.py
+++ b/components/flushnews.py
@@ -5,6 +5,8 @@ from meya import Component
 class HelloWorld(Component):
 
     def start(self):
+        # reset content refresh time stamp
+        self.db.bot.set('content_refresh_ts', 0)
         # flush the content database
         content_list = self.db.table('content').filter()
         for content in content_list:


### PR DESCRIPTION
When resetting content also reset the time stamp for refresh otherwise the user has to wait till after the time stamp to get any news.